### PR TITLE
feat: add ClearML API configuration to resolve setup warning

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,17 @@ clearml:
   tags: ["deep_learning", "classification", "kaggle"]
   auto_connect_frameworks: true
   auto_connect_arg_parser: true
+  
+  # Account Configuration
+  # Replace with your actual ClearML credentials
+  # Get these from: https://app.clear.ml/settings/workspace-configuration
+  api:
+    web_server: "https://app.clear.ml"
+    api_server: "https://api.clear.ml"
+    files_server: "https://files.clear.ml"
+    # Uncomment and add your credentials:
+    # access_key: "YOUR_ACCESS_KEY_HERE"
+    # secret_key: "YOUR_SECRET_KEY_HERE"
 
 # Evaluation Metrics
 evaluation:


### PR DESCRIPTION
Adds ClearML server endpoints and credential placeholders to config.yaml to resolve "ClearML is not configured on this machine" warning.

Users need to uncomment and add their actual credentials from:
https://app.clear.ml/settings/workspace-configuration

Fixes #4

Generated with [Claude Code](https://claude.ai/code)