### PR TITLE
fix: add weights_only=False parameter to torch.load calls for PyTorch 2.6 compatibility

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -68,7 +68,7 @@ class SpaceshipPredictor:
             raise FileNotFoundError(f"Model file {self.model_path} not found")
         
         # Load checkpoint
-        checkpoint = torch.load(self.model_path, map_location=self.device)
+        checkpoint = torch.load(self.model_path, map_location=self.device, weights_only=False)
         
         # Get model configuration
         if 'config' in checkpoint:
@@ -122,7 +122,7 @@ class SpaceshipPredictor:
             self.model = create_model(input_size, self.config)
             
             # Load model weights
-            checkpoint = torch.load(self.model_path, map_location=self.device)
+            checkpoint = torch.load(self.model_path, map_location=self.device, weights_only=False)
             self.model.load_state_dict(checkpoint['model_state_dict'])
             self.model.to(self.device)
             self.model.eval()


### PR DESCRIPTION
Fixes #6

This PR resolves the PyTorch 2.6 compatibility issue in predict.py where torch.load was failing due to the default weights_only parameter change.

## Changes
- Added weights_only=False parameter to both torch.load calls in predict.py (lines 71 and 125)
- Maintains backward compatibility for trusted model files
- Resolves UnpicklingError caused by PyTorch 2.6 default weights_only=True

Generated with [Claude Code](https://claude.ai/code)