### PR TITLE
fix: handle list values in ClearML model info logging

### DIFF
--- a/train.py
+++ b/train.py
@@ -340,7 +340,13 @@ class SpaceshipTrainer:
         
         if self.clearml_logger:
             for key, value in model_info.items():
-                self.clearml_logger.report_single_value(f"model/{key}", value)
+                # Handle list values by converting to string or reporting as text
+                if isinstance(value, list):
+                    # Convert list to string for logging
+                    self.clearml_logger.report_text(f"model/{key}", str(value))
+                else:
+                    # Report scalar values normally
+                    self.clearml_logger.report_single_value(f"model/{key}", value)
     
     def train_epoch(self, train_loader: DataLoader) -> float:
         """Train for one epoch."""


### PR DESCRIPTION
Fixes TypeError in train.py where list values from model info were being passed to ClearML's report_single_value() method.

## Changes:
- Added type checking for list values in model info logging
- Use report_text() for list values (hidden_sizes, dropout_rates)
- Keep report_single_value() for scalar values (total_parameters)

Fixes #10

Generated with [Claude Code](https://claude.ai/code)